### PR TITLE
Make helper plugin autoloadable

### DIFF
--- a/src/HelperLocator.php
+++ b/src/HelperLocator.php
@@ -61,10 +61,10 @@ class HelperLocator extends \Qiq\HelperLocator
             return true;
         }
 
-        $mabeyHelper = 'Qiq\Helper\\' . $name;
-        if (class_exists($mabeyHelper)) {
+        $maybeHelper = 'Qiq\Helper\\' . $name;
+        if (class_exists($maybeHelper)) {
             if (! isset($this->factories[$name])) {
-                $this->factories[$name] = fn () => new $mabeyHelper($this->escape);
+                $this->factories[$name] = fn () => new $maybeHelper($this->escape);
             }
 
             return true;

--- a/src/HelperLocator.php
+++ b/src/HelperLocator.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\QiqModule;
+
+use Qiq\Escape;
+use Qiq\Exception;
+use Qiq\Helper;
+
+use function class_exists;
+use function function_exists;
+
+class HelperLocator extends \Qiq\HelperLocator
+{
+    public static function new(?Escape $escape = null): self
+    {
+        $escape ??= new Escape('utf-8');
+
+        return new static([
+            'a'      => static fn () => new Helper\EscapeAttr($escape),
+            'c'      => static fn () => new Helper\EscapeCss($escape),
+            'escape' => static fn () => $escape,
+            'h'      => static fn () => new Helper\EscapeHtml($escape),
+            'u'      => static fn () => new Helper\EscapeUrl($escape),
+        ], $escape);
+    }
+
+    protected array $factories = [];
+    protected array $instances = [];
+    protected Escape $escape;
+
+    public function __construct(array $factories, ?Escape $escape = null)
+    {
+        $this->factories = $factories;
+        $this->escape  = $escape ?: new Escape('utf-8');
+    }
+
+    public function __call(string $name, array $args): mixed
+    {
+        return $this->get($name)(...$args);
+    }
+
+    public function set(string $name, mixed /* callable */ $callable): void
+    {
+        $this->factories[$name] = $callable;
+        unset($this->instances[$name]);
+    }
+
+    public function has(string $name): bool
+    {
+        if (isset($this->factories[$name]) || isset($this->instances[$name])) {
+            return true;
+        }
+
+        $func = '\\' . $name;
+
+        if (function_exists($name)) {
+            $this->instances[$name] = $func;
+
+            return true;
+        }
+
+        $mabeyHelper = 'Qiq\Helper\\' . $name;
+        if (class_exists($mabeyHelper)) {
+            if (! isset($this->factories[$name])) {
+                $this->factories[$name] = fn () => new $mabeyHelper($this->escape);
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function get(string $name): mixed
+    {
+        if (! $this->has($name)) {
+            throw new Exception\HelperNotFound($name);
+        }
+
+        if (! isset($this->instances[$name])) {
+            $factory = $this->factories[$name];
+            $this->instances[$name] = $factory();
+        }
+
+        return $this->instances[$name];
+    }
+}

--- a/src/HelperLocatorProvider.php
+++ b/src/HelperLocatorProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\QiqModule;
+
+use Ray\Di\ProviderInterface;
+
+class HelperLocatorProvider implements ProviderInterface
+{
+    public function get(): \Qiq\HelperLocator
+    {
+        return HelperLocator::new();
+    }
+}

--- a/src/QiqModule.php
+++ b/src/QiqModule.php
@@ -5,6 +5,12 @@ declare(strict_types=1);
 namespace BEAR\QiqModule;
 
 use BEAR\Resource\RenderInterface;
+use Qiq\Compiler\Compiler;
+use Qiq\Compiler\QiqCompiler;
+use Qiq\HelperLocator;
+use Qiq\Template;
+use Qiq\TemplateCore;
+use Qiq\TemplateLocator;
 use Ray\Di\AbstractModule;
 use Ray\Di\Scope;
 
@@ -20,9 +26,17 @@ final class QiqModule extends AbstractModule
 
     protected function configure(): void
     {
+        $this->bind(TemplateCore::class)->to(Template::class)->in(Scope::SINGLETON);
+        $this->bind(TemplateLocator::class)->toConstructor(
+            TemplateLocator::class,
+            ['paths' => 'qiq_paths', 'extension' => 'qiq_extension']
+        );
         $this->bind()->annotatedWith('qiq_template_dir')->toInstance($this->templateDir);
+        $this->bind()->annotatedWith('qiq_paths')->toInstance([$this->templateDir]);
+        $this->bind()->annotatedWith('qiq_extension')->toInstance('.php');
         $this->bind(RenderInterface::class)->to(QiqRenderer::class)->in(Scope::SINGLETON);
-
+        $this->bind(HelperLocator::class)->toProvider(HelperLocatorProvider::class);
+        $this->bind(Compiler::class)->to(QiqCompiler::class);
         $this->install(new QiqErrorModule($this->errorViewName));
     }
 }

--- a/src/QiqRenderer.php
+++ b/src/QiqRenderer.php
@@ -6,7 +6,7 @@ namespace BEAR\QiqModule;
 
 use BEAR\Resource\RenderInterface;
 use BEAR\Resource\ResourceObject;
-use Qiq\Template;
+use Qiq\TemplateCore;
 use Ray\Di\Di\Named;
 use ReflectionClass;
 
@@ -16,15 +16,16 @@ use function is_array;
 final class QiqRenderer implements RenderInterface
 {
     public function __construct(
+        private TemplateCore $template,
         #[Named('qiq_template_dir')] private string $templateDir,
-        #[Named('qiq_cache_path')] private ?string $cachePath = null
+        #[Named('qiq_cache_path')] private ?string $cachePath = null,
     ) {
     }
 
     public function render(ResourceObject $ro): string
     {
         $class = new ReflectionClass($ro);
-        $tpl = Template::new(paths: $this->templateDir, cachePath: $this->cachePath);
+        $tpl = $this->template;
         $name = $class->getShortName();
         $tpl->setView($name);
         assert(is_array($ro->body));

--- a/tests/QiqErrorPageHandlerTest.php
+++ b/tests/QiqErrorPageHandlerTest.php
@@ -63,6 +63,6 @@ class QiqErrorPageHandlerTest extends TestCase
 
         $this->assertSame(503, FakeHttpResponder::$code);
         $this->assertSame('text/html; charset=utf-8', FakeHttpResponder::$headers['content-type']);
-        $this->assertStringStartsWith('custom error page code: 503 message: Service Unavailable', FakeHttpResponder::$content);
+        $this->assertStringStartsWith('code: 503 message: Service Unavailable', FakeHttpResponder::$content);
     }
 }

--- a/tests/QiqRendererTest.php
+++ b/tests/QiqRendererTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BEAR\QiqModule;
 
+use BEAR\Resource\RenderInterface;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\AbstractModule;
 use Ray\Di\Injector;
@@ -20,6 +21,12 @@ class QiqRendererTest extends TestCase
         $qiqTemplateDir = dirname(__DIR__) . '/tests/Fake/templates';
         $this->module = new QiqModule($qiqTemplateDir);
         parent::setUp();
+    }
+
+    public function testRenderModule(): void
+    {
+        $render = (new Injector($this->module))->getInstance(RenderInterface::class);
+        $this->assertInstanceOf(QiqRenderer::class, $render);
     }
 
     public function testRender(): void


### PR DESCRIPTION
* Template::new()で都度生成していたQiqオブジェクトをシングルトンでインジェクト
* HelperLocaterをサービスロケーターではなく、オンデマンドなオートロードに対応したQiqModule独自のHelperLocaterにしていますが、本家にもPRしています。

https://github.com/qiqphp/qiq/pull/7#pullrequestreview-876506800