### PR TITLE
Remove bin config

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -9,16 +9,21 @@ jobs:
   coding-standards:
     name: Coding Standards
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        operating-system:
+          - ubuntu-latest
+        php-version:
+          - '8.0'
+          - '8.1'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup PHP
+      - name: Setup PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2
         with:
-          php-version:
-            - '8.0'
-            - '8.1'
+          php-version: ${{ matrix.php-version }}
           tools: cs2pr
           coverage: none
 

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
             ]
         }
     },
-    "bin": ["bin/qiq_stubgen.php"],
     "scripts": {
         "setup": "php bin/setup.php",
         "test": "./vendor/bin/phpunit",


### PR DESCRIPTION
composer.jsonから未使用のbin設定を削除しました。

composer2.2系（LTS）でcomposer binを利用していると、composer install 時に以下のようなエラーが発生してbinのインストールが止まってしまうようです。

```
Generating autoload files
    Skipped installation of bin bin/qiq_stubgen.php for package bear/qiq-module: file not found in package
```
